### PR TITLE
Fix escape bug in Descriptor - [M-04] by @IAm0x52 

### DIFF
--- a/.changeset/grumpy-starfishes-pump.md
+++ b/.changeset/grumpy-starfishes-pump.md
@@ -1,0 +1,5 @@
+---
+"@cobuild/revolution": patch
+---
+
+fix bug with escape function in Descriptor breaking over 255 len strings

--- a/packages/revolution/src/Descriptor.sol
+++ b/packages/revolution/src/Descriptor.sol
@@ -116,7 +116,7 @@ contract Descriptor is IDescriptor, RevolutionVersion, UUPS, Ownable2StepUpgrade
         if (quotesCount > 0) {
             bytes memory escapedBytes = new bytes(len + (quotesCount));
             uint256 index;
-            for (uint8 i = 0; i < len; i++) {
+            for (uint256 i = 0; i < len; i++) {
                 if (strBytes[i] == '"') {
                     escapedBytes[index++] = "\\";
                 } else if (strBytes[i] == "\\") {

--- a/packages/revolution/test/descriptor/UriData.t.sol
+++ b/packages/revolution/test/descriptor/UriData.t.sol
@@ -143,6 +143,28 @@ contract DescriptorURIDataTest is DescriptorTest {
         );
     }
 
+    function testLongDescription() public {
+        uint256 tokenId = 1;
+        //previously the escape function broke on long strings that needed to be escaped
+        ICultureIndex.ArtPieceMetadata memory metadata = ICultureIndex.ArtPieceMetadata({
+            name: "Test Art",
+            description: 'However, based on the provided " compiler error, it seems that inserting the emoji directly might still cause issues. If the direct insertion of an emoji is problematic (e.g., due to tooling, encoding settings, or Solidity version constraints), and if the unicode prefix approach as described does not resolve the issue, consider representing the emoji through its hexadecimal escape sequence within the unicode prefixed string. Heres how you might attempt it:',
+            mediaType: ICultureIndex.MediaType.IMAGE,
+            image: "https://example.com/image.png",
+            text: "",
+            animationUrl: ""
+        });
+
+        string memory uri = descriptor.dataURI(tokenId, metadata);
+        assertTrue(bytes(uri).length > 0, "dataURI should not be empty");
+        // Check if the string contains the base64 identifier which indicates a base64 encoded data URI
+        assertEq(
+            substring(bytes(uri), 0, 29),
+            "data:application/json;base64,",
+            "dataURI should start with 'data:application/json;base64,'"
+        );
+    }
+
     /// @notice Test `genericDataURI` returns valid base64 encoded data URI
     function testGenericDataURI() public {
         ICultureIndex.ArtPieceMetadata memory metadata = ICultureIndex.ArtPieceMetadata({

--- a/packages/revolution/test/descriptor/UriData.t.sol
+++ b/packages/revolution/test/descriptor/UriData.t.sol
@@ -165,6 +165,36 @@ contract DescriptorURIDataTest is DescriptorTest {
         );
     }
 
+    function testMaliciousDescription() public {
+        string
+            memory description = 'This is a test cases: "Embedded Quotes", \\Double Backslashes\\, \nNewline, \rCarriage Return, \tTab, \\bBackspace, \\fForm Feed, http://example.com/?param=value&another=value, \\u{1F600} Emoji, \u0000Null Byte, \' and Control Characters like \u001F.';
+        ICultureIndex.ArtPieceMetadata memory metadata = ICultureIndex.ArtPieceMetadata({
+            name: "",
+            description: description,
+            mediaType: ICultureIndex.MediaType.IMAGE,
+            image: "https://example.com/image.png",
+            text: "",
+            animationUrl: ""
+        });
+
+        string memory uri = descriptor.dataURI(1, metadata);
+
+        assertTrue(bytes(uri).length > 0, "dataURI should not be empty");
+
+        // Check if the string contains the base64 identifier which indicates a base64 encoded data URI
+        assertEq(
+            substring(bytes(uri), 0, 29),
+            "data:application/json;base64,",
+            "dataURI should start with 'data:application/json;base64,'"
+        );
+
+        // parseJson and ensure the description is escaped
+        string memory metadataJson = decodeMetadata(uri);
+
+        //ensure doesn't revert
+        parseJson(metadataJson);
+    }
+
     /// @notice Test `genericDataURI` returns valid base64 encoded data URI
     function testGenericDataURI() public {
         ICultureIndex.ArtPieceMetadata memory metadata = ICultureIndex.ArtPieceMetadata({


### PR DESCRIPTION
```
When constructing the TokenURI, special characters must be escaped before they can packed into a JSON to prevent a range of potential issues when displaying/retrieving the image. The contract utilizes the escape function to sanitize strings.

When iterating through the string, it only uses a uint8 for the loop index. This is problematic as any string over the length of 255 will cause the function to revert due to overflow, breaking the URI of the token.
```